### PR TITLE
Add startup script for git update and dependency installation

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Updating git repository..."
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if git remote get-url origin >/dev/null 2>&1; then
+        git pull --ff-only
+    else
+        echo "No git remote configured; skipping git pull."
+    fi
+else
+    echo "Not a git repository; skipping git pull."
+fi
+
+if command -v composer >/dev/null 2>&1; then
+    echo "Installing PHP dependencies..."
+    composer install --no-interaction --prefer-dist --no-progress
+else
+    echo "Composer not found; skipping PHP dependencies installation."
+fi
+
+if [ -f package.json ]; then
+    if command -v npm >/dev/null 2>&1; then
+        echo "Installing Node dependencies..."
+        npm install --no-progress
+    else
+        echo "npm not found; skipping Node dependencies installation."
+    fi
+fi


### PR DESCRIPTION
## Summary
- add startup script to pull latest code and install PHP/Node dependencies

## Testing
- `./startup.sh` *(fails: carbon/carbon package could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ab1e148083249a6ea98d1187ba47