### PR TITLE
Add environment config and database backup utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /storage/logs/*
 !/storage/logs/.gitkeep
 .env
-config.php
 composer.lock
 *.log
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Environment-based configuration bootstrap (`config.php`)
+- Database backup utility script (`tools/backup-database.php`)
+
 ### Planned for v1.1 (Phase 1)
 - Swiss Ephemeris PHP library integration
 - MySQL database schema implementation

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=8.0",
         "ext-json": "*",
         "ext-pdo": "*",
-        "carbon/carbon": "^2.0",
+        "nesbot/carbon": "^2.0",
         "vlucas/phpdotenv": "^5.0",
         "mpdf/mpdf": "^8.0"
     },

--- a/config.php
+++ b/config.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+use Dotenv\Dotenv;
+
+// Load Composer autoloader if available for Dotenv and other dependencies
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+
+// Load environment variables from .env if present
+if (class_exists(Dotenv::class)) {
+    $dotenv = Dotenv::createImmutable(__DIR__);
+    $dotenv->safeLoad();
+}
+
+// Helper to retrieve environment variables with defaults
+if (!function_exists('env')) {
+    function env(string $key, mixed $default = null): mixed
+    {
+        return $_ENV[$key] ?? $_SERVER[$key] ?? $default;
+    }
+}
+
+// Application settings
+define('APP_ENV', (string) env('APP_ENV', 'production'));
+define('APP_DEBUG', filter_var(env('APP_DEBUG', false), FILTER_VALIDATE_BOOLEAN));
+define('APP_URL', (string) env('APP_URL', 'http://localhost'));
+define('APP_TIMEZONE', (string) env('APP_TIMEZONE', 'UTC'));
+
+// Paths
+define('ROOT_PATH', __DIR__);
+define('STORAGE_PATH', ROOT_PATH . '/storage');
+define('LOGS_PATH', STORAGE_PATH . '/logs');
+
+// Database configuration
+define('DB_HOST', (string) env('DB_HOST', 'localhost'));
+define('DB_PORT', (int) env('DB_PORT', 3306));
+define('DB_NAME', (string) env('DB_NAME', 'quantum_astrology'));
+define('DB_USER', (string) env('DB_USER', 'root'));
+define('DB_PASS', (string) env('DB_PASS', ''));
+define('DB_CHARSET', (string) env('DB_CHARSET', 'utf8mb4'));
+
+// Cache configuration
+define('CACHE_ENABLED', filter_var(env('CACHE_ENABLED', true), FILTER_VALIDATE_BOOLEAN));
+define('CACHE_TTL', (int) env('CACHE_TTL', 3600));
+
+// Swiss Ephemeris configuration
+define('SWEPH_PATH', (string) env('SWEPH_PATH', '/usr/local/bin/swetest'));
+define('SWEPH_DATA_PATH', (string) env('SWEPH_DATA_PATH', ROOT_PATH . '/data/ephemeris'));
+
+// Set default timezone
+if (function_exists('date_default_timezone_set')) {
+    date_default_timezone_set(APP_TIMEZONE);
+}

--- a/tools/backup-database.php
+++ b/tools/backup-database.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../classes/Core/Logger.php';
+
+use QuantumAstrology\Core\Logger;
+
+echo "Backing up Quantum Astrology database...\n";
+
+$backupDir = STORAGE_PATH . '/backups';
+if (!is_dir($backupDir)) {
+    mkdir($backupDir, 0775, true);
+}
+
+$filename = sprintf('%s/backup_%s.sql', $backupDir, date('Ymd_His'));
+
+$command = sprintf(
+    'mysqldump --host=%s --port=%d --user=%s --password=%s %s > %s',
+    escapeshellarg(DB_HOST),
+    DB_PORT,
+    escapeshellarg(DB_USER),
+    escapeshellarg(DB_PASS),
+    escapeshellarg(DB_NAME),
+    escapeshellarg($filename)
+);
+
+$exitCode = 0;
+system($command, $exitCode);
+
+if ($exitCode === 0) {
+    echo "Backup created at {$filename}\n";
+    Logger::info('Database backup created', ['file' => $filename]);
+} else {
+    echo "Database backup failed\n";
+    Logger::error('Database backup failed', ['command' => $command, 'exit_code' => $exitCode]);
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- add environment-aware configuration bootstrap with Dotenv support
- provide CLI database backup script and backup storage directory
- fix composer dependency typo and document new tooling in changelog

## Testing
- `composer install`
- `php -l config.php`
- `php -l tools/backup-database.php`
- `php test-syntax.php`
- `php tools/backup-database.php` *(fails: mysqldump not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1be678d908324ae6de50f4413d6eb