### PR TITLE
Handle duplicate user registration errors

### DIFF
--- a/pages/auth/register.php
+++ b/pages/auth/register.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use QuantumAstrology\Core\Auth;
 use QuantumAstrology\Core\Session;
+use QuantumAstrology\Core\User;
 
 Auth::requireGuest();
 
@@ -23,12 +24,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $errors = Auth::getValidationErrors($formData);
     
     if (empty($errors)) {
-        $user = Auth::register($formData);
-        
-        if ($user) {
+        $result = Auth::register($formData);
+
+        if ($result instanceof User) {
             Session::flash('success', 'Welcome to Quantum Astrology! Your account has been created.');
             header('Location: /dashboard');
             exit;
+        }
+
+        if ($result === Auth::ERROR_DUPLICATE) {
+            $errors[] = 'Email or username already exists.';
         } else {
             $errors[] = 'Registration failed. Please try again.';
         }


### PR DESCRIPTION
## Summary
- return a dedicated `ERROR_DUPLICATE` code from `User::create()` when a unique constraint fails
- propagate duplicate registration errors in `Auth::register()` and simplify validation
- show duplicate registration feedback on the signup page

## Testing
- `php -l classes/Core/User.php`
- `php -l classes/Core/Auth.php`
- `php -l pages/auth/register.php`
- `php test-syntax.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1dacc316c832499fa8baf3c396ebe