### PR TITLE
Require password confirmation during registration

### DIFF
--- a/classes/Core/Auth.php
+++ b/classes/Core/Auth.php
@@ -95,30 +95,34 @@ class Auth
     
     private static function validateRegistration(array $data): bool
     {
-        $required = ['username', 'email', 'password'];
-        
+        $required = ['username', 'email', 'password', 'password_confirm'];
+
         foreach ($required as $field) {
             if (empty($data[$field])) {
                 return false;
             }
         }
-        
+
+        if ($data['password'] !== $data['password_confirm']) {
+            return false;
+        }
+
         if (!filter_var($data['email'], FILTER_VALIDATE_EMAIL)) {
             return false;
         }
-        
+
         if (strlen($data['password']) < 8) {
             return false;
         }
-        
+
         if (User::findByEmail($data['email'])) {
             return false;
         }
-        
+
         if (User::findByUsername($data['username'])) {
             return false;
         }
-        
+
         return true;
     }
     
@@ -146,7 +150,9 @@ class Auth
             $errors[] = 'Password must be at least 8 characters long';
         }
         
-        if (!empty($data['password_confirm']) && $data['password'] !== $data['password_confirm']) {
+        if (empty($data['password_confirm'])) {
+            $errors[] = 'Password confirmation is required';
+        } elseif ($data['password'] !== $data['password_confirm']) {
             $errors[] = 'Password confirmation does not match';
         }
         

--- a/pages/auth/register.php
+++ b/pages/auth/register.php
@@ -14,6 +14,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'username' => trim($_POST['username'] ?? ''),
         'email' => trim($_POST['email'] ?? ''),
         'password' => $_POST['password'] ?? '',
+        // Provide confirmation field for registration validation
         'password_confirm' => $_POST['password_confirm'] ?? '',
         'first_name' => trim($_POST['first_name'] ?? ''),
         'last_name' => trim($_POST['last_name'] ?? ''),


### PR DESCRIPTION
## Summary
- Enforce `password_confirm` field in registration validation and ensure passwords match.
- Report errors when confirmation is missing or mismatched.
- Document required confirmation in registration form.

## Testing
- `php -l classes/Core/Auth.php`
- `php -l pages/auth/register.php`
- `php test-syntax.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1dacd6b888324bcc9c70d690bd371