### PR TITLE
Add SQLite fallback and placeholder pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ DB_PORT=3306
 DB_NAME=quantum_astrology
 DB_USER=root
 DB_PASS=
+DB_SQLITE_PATH=./storage/database.sqlite
 
 # Swiss Ephemeris Configuration (Phase 1)
 SWEPH_PATH=/usr/local/bin/swetest

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !/storage/cache/.gitkeep
 /storage/logs/*
 !/storage/logs/.gitkeep
+/storage/*.sqlite
 .env
 composer.lock
 *.log

--- a/classes/Charts/Chart.php
+++ b/classes/Charts/Chart.php
@@ -43,7 +43,7 @@ class Chart
                 :user_id, :name, :chart_type, :birth_datetime, :birth_timezone,
                 :birth_latitude, :birth_longitude, :birth_location_name, :house_system,
                 :chart_data, :planetary_positions, :house_positions, :aspects,
-                :calculation_metadata, :is_public, NOW(), NOW()
+                :calculation_metadata, :is_public, :created_at, :updated_at
             )";
 
             $params = [
@@ -61,7 +61,9 @@ class Chart
                 'house_positions' => json_encode($chartData['house_positions'] ?? null),
                 'aspects' => json_encode($chartData['aspects'] ?? null),
                 'calculation_metadata' => json_encode($chartData['calculation_metadata'] ?? null),
-                'is_public' => $chartData['is_public'] ?? false
+                'is_public' => $chartData['is_public'] ?? false,
+                'created_at' => date('Y-m-d H:i:s'),
+                'updated_at' => date('Y-m-d H:i:s')
             ];
 
             Connection::query($sql, $params);
@@ -242,8 +244,9 @@ class Chart
             return true;
         }
         
-        $updateFields[] = "updated_at = NOW()";
+        $updateFields[] = "updated_at = :updated_at";
         $sql = "UPDATE charts SET " . implode(', ', $updateFields) . " WHERE id = :id";
+        $params['updated_at'] = date('Y-m-d H:i:s');
         
         try {
             Connection::query($sql, $params);

--- a/classes/Database/Connection.php
+++ b/classes/Database/Connection.php
@@ -9,7 +9,7 @@ use PDOException;
 class Connection
 {
     private static ?PDO $instance = null;
-    
+
     public static function getInstance(): PDO
     {
         if (self::$instance === null) {
@@ -21,19 +21,105 @@ class Connection
                     DB_NAME,
                     DB_CHARSET
                 );
-                
+
                 self::$instance = new PDO($dsn, DB_USER, DB_PASS, [
                     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
                     PDO::ATTR_EMULATE_PREPARES => false,
                 ]);
             } catch (PDOException $e) {
-                error_log("Database connection failed: " . $e->getMessage());
-                throw new PDOException("Database connection failed");
+                error_log("Database connection failed: " . $e->getMessage() . ". Falling back to SQLite.");
+
+                try {
+                    @mkdir(dirname(DB_SQLITE_PATH), 0755, true);
+                    $dsn = 'sqlite:' . DB_SQLITE_PATH;
+                    self::$instance = new PDO($dsn, null, null, [
+                        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                        PDO::ATTR_EMULATE_PREPARES => false,
+                    ]);
+
+                    self::initializeSqlite(self::$instance);
+                } catch (PDOException $sqliteException) {
+                    error_log("SQLite fallback failed: " . $sqliteException->getMessage());
+                    throw new PDOException("Database connection failed");
+                }
             }
         }
-        
+
         return self::$instance;
+    }
+
+    private static function initializeSqlite(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE,
+            email TEXT UNIQUE,
+            password_hash TEXT,
+            first_name TEXT,
+            last_name TEXT,
+            timezone TEXT DEFAULT "UTC",
+            email_verified_at TEXT NULL,
+            last_login_at TEXT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+
+        $pdo->exec('CREATE TABLE IF NOT EXISTS charts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            chart_type TEXT DEFAULT "natal",
+            birth_datetime TEXT NOT NULL,
+            birth_timezone TEXT NOT NULL DEFAULT "UTC",
+            birth_latitude REAL NOT NULL,
+            birth_longitude REAL NOT NULL,
+            birth_location_name TEXT,
+            house_system TEXT DEFAULT "P",
+            chart_data TEXT,
+            planetary_positions TEXT,
+            house_positions TEXT,
+            aspects TEXT,
+            calculation_metadata TEXT,
+            is_public INTEGER DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+
+        $pdo->exec('CREATE TABLE IF NOT EXISTS birth_profiles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            birth_datetime TEXT NOT NULL,
+            birth_timezone TEXT NOT NULL DEFAULT "UTC",
+            birth_latitude REAL NOT NULL,
+            birth_longitude REAL NOT NULL,
+            birth_location_name TEXT,
+            notes TEXT,
+            is_private INTEGER DEFAULT 1,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+
+        $pdo->exec('CREATE TABLE IF NOT EXISTS chart_sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            chart_id INTEGER NOT NULL,
+            session_data TEXT,
+            view_settings TEXT,
+            aspect_settings TEXT,
+            display_preferences TEXT,
+            last_accessed TEXT DEFAULT CURRENT_TIMESTAMP,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+
+        $pdo->exec('CREATE TABLE IF NOT EXISTS migrations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            migration TEXT,
+            batch INTEGER
+        )');
     }
     
     public static function query(string $sql, array $params = []): \PDOStatement

--- a/config.php
+++ b/config.php
@@ -40,6 +40,7 @@ define('DB_NAME', (string) env('DB_NAME', 'quantum_astrology'));
 define('DB_USER', (string) env('DB_USER', 'root'));
 define('DB_PASS', (string) env('DB_PASS', ''));
 define('DB_CHARSET', (string) env('DB_CHARSET', 'utf8mb4'));
+define('DB_SQLITE_PATH', (string) env('DB_SQLITE_PATH', STORAGE_PATH . '/database.sqlite'));
 
 // Cache configuration
 define('CACHE_ENABLED', filter_var(env('CACHE_ENABLED', true), FILTER_VALIDATE_BOOLEAN));

--- a/pages/charts/transits/index.php
+++ b/pages/charts/transits/index.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+use QuantumAstrology\Core\Auth;
+
+Auth::requireLogin();
+
+$pageTitle = 'Transits - Quantum Astrology';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($pageTitle) ?></title>
+    <link rel="stylesheet" href="/assets/css/quantum-dashboard.css">
+    <style>
+        .transits-container {
+            max-width: 800px;
+            margin: 4rem auto;
+            text-align: center;
+        }
+        .transits-title {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+            background: linear-gradient(135deg, var(--quantum-primary), var(--quantum-gold));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+        .transits-description {
+            color: rgba(255, 255, 255, 0.8);
+        }
+    </style>
+</head>
+<body>
+<div class="particles-container"></div>
+<div class="transits-container">
+    <h1 class="transits-title">Transits</h1>
+    <p class="transits-description">Transit calculations will be available soon.</p>
+</div>
+<script>
+    const particlesContainer = document.querySelector('.particles-container');
+    function createParticle() {
+        const particle = document.createElement('div');
+        particle.className = 'particle';
+        particle.style.left = Math.random() * 100 + '%';
+        particle.style.animationDelay = Math.random() * 15 + 's';
+        particle.style.animationDuration = (Math.random() * 10 + 10) + 's';
+        particlesContainer.appendChild(particle);
+        setTimeout(() => particle.remove(), 20000);
+    }
+    for (let i = 0; i < 50; i++) {
+        setTimeout(createParticle, i * 200);
+    }
+    setInterval(createParticle, 1000);
+</script>
+</body>
+</html>
+

--- a/pages/reports/index.php
+++ b/pages/reports/index.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+use QuantumAstrology\Core\Auth;
+
+Auth::requireLogin();
+
+$pageTitle = 'Reports - Quantum Astrology';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($pageTitle) ?></title>
+    <link rel="stylesheet" href="/assets/css/quantum-dashboard.css">
+    <style>
+        .reports-container {
+            max-width: 800px;
+            margin: 4rem auto;
+            text-align: center;
+        }
+        .reports-title {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+            background: linear-gradient(135deg, var(--quantum-primary), var(--quantum-gold));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+        .reports-description {
+            color: rgba(255, 255, 255, 0.8);
+        }
+    </style>
+</head>
+<body>
+<div class="particles-container"></div>
+<div class="reports-container">
+    <h1 class="reports-title">Reports</h1>
+    <p class="reports-description">Detailed astrological reports are coming soon.</p>
+    </div>
+<script>
+    const particlesContainer = document.querySelector('.particles-container');
+    function createParticle() {
+        const particle = document.createElement('div');
+        particle.className = 'particle';
+        particle.style.left = Math.random() * 100 + '%';
+        particle.style.animationDelay = Math.random() * 15 + 's';
+        particle.style.animationDuration = (Math.random() * 10 + 10) + 's';
+        particlesContainer.appendChild(particle);
+        setTimeout(() => particle.remove(), 20000);
+    }
+    for (let i = 0; i < 50; i++) {
+        setTimeout(createParticle, i * 200);
+    }
+    setInterval(createParticle, 1000);
+</script>
+</body>
+</html>
+

--- a/tools/test-chart-generation.php
+++ b/tools/test-chart-generation.php
@@ -85,9 +85,14 @@ try {
 echo "\n4. Testing Database Connectivity...\n";
 try {
     $pdo = QuantumAstrology\Database\Connection::getInstance();
-    
-    // Test tables exist
-    $stmt = $pdo->query("SHOW TABLES");
+
+    // Test tables exist for current driver
+    $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+    if ($driver === 'sqlite') {
+        $stmt = $pdo->query("SELECT name FROM sqlite_master WHERE type='table'");
+    } else {
+        $stmt = $pdo->query("SHOW TABLES");
+    }
     $tables = $stmt->fetchAll(PDO::FETCH_COLUMN);
     
     $expectedTables = ['users', 'charts', 'birth_profiles', 'chart_sessions', 'migrations'];


### PR DESCRIPTION
## Summary
- add SQLite fallback with automatic table initialization when MySQL is unavailable
- make Chart timestamps database-independent
- add placeholder pages for reports and transits
- allow environment test script to detect SQLite tables

## Testing
- `composer install`
- `php tools/test-chart-generation.php`


------
https://chatgpt.com/codex/tasks/task_e_68c249b0fdbc8324b42d23114ef1c9b5