### PR TITLE
Handle numeric coordinates in chart creation

### DIFF
--- a/pages/charts/create.php
+++ b/pages/charts/create.php
@@ -384,7 +384,7 @@ $pageTitle = 'Create New Chart - Quantum Astrology';
                                step="0.000001"
                                min="-90"
                                max="90"
-                               value="<?= htmlspecialchars($formData['birth_latitude'] ?? '') ?>"
+                               value="<?= htmlspecialchars((string)($formData['birth_latitude'] ?? '')) ?>"
                                required>
                         <span class="coordinate-label">°N</span>
                     </div>
@@ -399,7 +399,7 @@ $pageTitle = 'Create New Chart - Quantum Astrology';
                                step="0.000001"
                                min="-180"
                                max="180"
-                               value="<?= htmlspecialchars($formData['birth_longitude'] ?? '') ?>"
+                               value="<?= htmlspecialchars((string)($formData['birth_longitude'] ?? '')) ?>"
                                required>
                         <span class="coordinate-label">°E</span>
                     </div>


### PR DESCRIPTION
## Summary
- Cast latitude and longitude values to strings before escaping in chart creation form to avoid `htmlspecialchars` type errors.

## Testing
- `php -l pages/charts/create.php`
- `php tools/test-chart-generation.php` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c317b604e48324839bf0072f2fa807