### PR TITLE
Add PHPUnit testing infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,13 @@ The application uses a normalized database structure:
 
 ### Testing
 
-Run the test suite to verify chart accuracy:
+Run the automated test suite:
+
+```bash
+composer test
+```
+
+Run the chart generation script to verify chart accuracy:
 
 ```bash
 php tools/test-chart-generation.php

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,16 @@
         "psr-4": {
             "QuantumAstrology\\": "classes/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "QuantumAstrology\\Tests\\": "tests/"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Quantum Astrology Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Core/SessionTest.php
+++ b/tests/Core/SessionTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace QuantumAstrology\Tests\Core;
+
+use PHPUnit\Framework\TestCase;
+use QuantumAstrology\Core\Session;
+
+final class SessionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        $_SESSION = [];
+    }
+
+    /** @runInSeparateProcess */
+    public function testSetAndGet(): void
+    {
+        Session::set('foo', 'bar');
+        $this->assertSame('bar', Session::get('foo'));
+    }
+
+    /** @runInSeparateProcess */
+    public function testFlashStoresAndClears(): void
+    {
+        Session::flash('message', 'hello');
+        $this->assertTrue(Session::hasFlash('message'));
+        $this->assertSame('hello', Session::getFlash('message'));
+        $this->assertFalse(Session::hasFlash('message'));
+    }
+}


### PR DESCRIPTION
## Summary
- integrate PHPUnit and testing scripts via Composer
- add phpunit.xml config and sample Session test
- document how to run tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c31a77d06083248507be7515ccf461