### PR TITLE
Fix broken GitHub links in docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ Before installing Quantum Astrology, ensure your system meets these requirements
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/mestro57/quantum-astrology.git
+git clone https://github.com/meistro57/quantum-astrology.git
 cd quantum-astrology
 ```
 
@@ -293,7 +293,7 @@ If you encounter issues:
 
 ## Support
 
-- **GitHub Issues**: [Create an issue](https://github.com/mestro57/quantum-astrology/issues)
+- **GitHub Issues**: [Create an issue](https://github.com/meistro57/quantum-astrology/issues)
 - **Email**: mark@quantummindsunited.com
 - **Website**: [Quantum Minds United](https://quantummindsunited.com)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Quantum Astrology provides professional-grade astrological calculations and char
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/mestro57/quantum-astrology.git
+   git clone https://github.com/meistro57/quantum-astrology.git
    cd quantum-astrology
    ```
 


### PR DESCRIPTION
## Summary
- Correct GitHub repository URL in README installation instructions
- Update INSTALL guide links to point to existing GitHub repo and issue tracker

## Testing
- `php test-syntax.php`


------
https://chatgpt.com/codex/tasks/task_e_68c31f0d4ce8832499004894490ce458