### PR TITLE
Log chart creation failures

### DIFF
--- a/pages/charts/create.php
+++ b/pages/charts/create.php
@@ -5,6 +5,7 @@ use QuantumAstrology\Core\Auth;
 use QuantumAstrology\Core\Session;
 use QuantumAstrology\Charts\Chart;
 use QuantumAstrology\Core\SwissEphemeris;
+use QuantumAstrology\Core\Logger;
 
 Auth::requireLogin();
 
@@ -55,6 +56,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             header('Location: /charts/view?id=' . $chart->getId());
             exit;
         } else {
+            Logger::error('Chart creation failed', [
+                'user_id' => $user->getId(),
+                'chart_name' => $formData['name'] ?? null
+            ]);
             $errors[] = 'Failed to create chart. Please try again.';
         }
     }


### PR DESCRIPTION
## Summary
- log chart creation errors with context about the user and chart name

## Testing
- `php -l pages/charts/create.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c327053aac83249b1a2832927d2cbf