### PR TITLE
Improve coordinate validation and API error responses

### DIFF
--- a/api/chart_create.php
+++ b/api/chart_create.php
@@ -5,26 +5,104 @@ declare(strict_types=1);
 require __DIR__ . '/../classes/autoload.php';
 
 use QuantumAstrology\Charts\ChartService;
+use QuantumAstrology\Support\InputValidator;
 
 header('Content-Type: application/json');
 
-try {
-    $payload = json_decode(file_get_contents('php://input') ?: 'null', true);
-    if (!is_array($payload)) $payload = $_POST ?: [];
+/**
+ * Send a JSON error response with a consistent payload structure.
+ */
+function respond_error(int $status, string $code, string $message, array $fields = []): void
+{
+    http_response_code($status);
+    echo json_encode([
+        'ok' => false,
+        'error' => [
+            'code' => $code,
+            'message' => $message,
+            'fields' => $fields,
+        ],
+    ], JSON_PRETTY_PRINT);
+    exit;
+}
 
+$rawBody = file_get_contents('php://input');
+$payload = null;
+if ($rawBody !== false && trim($rawBody) !== '') {
+    $payload = json_decode($rawBody, true);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        respond_error(400, 'INVALID_JSON', 'Request body must be valid JSON.', [
+            'body' => json_last_error_msg(),
+        ]);
+    }
+}
+
+if (!is_array($payload)) {
+    $payload = $_POST ?: [];
+}
+
+$name       = trim((string) ($payload['name'] ?? ''));
+$birthDate  = trim((string) ($payload['birth_date'] ?? ''));
+$birthTime  = trim((string) ($payload['birth_time'] ?? ''));
+$houseInput = strtoupper(trim((string) ($payload['house_system'] ?? 'P')));
+$houseSystem = $houseInput !== '' ? $houseInput : 'P';
+
+$errors = [];
+
+if ($name === '') {
+    $errors['name'] = 'Chart name is required.';
+}
+if ($birthDate === '') {
+    $errors['birth_date'] = 'Birth date is required.';
+}
+if ($birthTime === '') {
+    $errors['birth_time'] = 'Birth time is required.';
+}
+
+$timezoneInput = $payload['birth_timezone'] ?? '';
+$timezoneInput = is_string($timezoneInput) ? trim($timezoneInput) : '';
+$birthTimezone = 'UTC';
+if ($timezoneInput !== '') {
+    try {
+        $birthTimezone = InputValidator::normaliseTimezone($timezoneInput);
+    } catch (\InvalidArgumentException $e) {
+        $errors['birth_timezone'] = $e->getMessage();
+    }
+}
+
+try {
+    $birthLatitude = InputValidator::parseLatitude($payload['birth_latitude'] ?? null);
+} catch (\InvalidArgumentException $e) {
+    $errors['birth_latitude'] = $e->getMessage();
+}
+
+try {
+    $birthLongitude = InputValidator::parseLongitude($payload['birth_longitude'] ?? null);
+} catch (\InvalidArgumentException $e) {
+    $errors['birth_longitude'] = $e->getMessage();
+}
+
+if (!empty($errors)) {
+    respond_error(422, 'VALIDATION_ERROR', 'There were problems with the data you submitted.', $errors);
+}
+
+try {
     $chart = ChartService::create(
-        trim($payload['name'] ?? ''),
-        trim($payload['birth_date'] ?? ''),
-        trim($payload['birth_time'] ?? ''),
-        trim($payload['birth_timezone'] ?? 'UTC'),
-        (float)($payload['birth_latitude'] ?? 0),
-        (float)($payload['birth_longitude'] ?? 0),
-        strtoupper(trim($payload['house_system'] ?? 'P'))
+        $name,
+        $birthDate,
+        $birthTime,
+        $birthTimezone,
+        $birthLatitude,
+        $birthLongitude,
+        $houseSystem
     );
+
+    if (!$chart) {
+        respond_error(500, 'CHART_CREATE_FAILED', 'Unable to create chart at this time.');
+    }
 
     http_response_code(201);
     echo json_encode(['ok' => true, 'chart' => $chart], JSON_PRETTY_PRINT);
 } catch (Throwable $e) {
-    http_response_code(400);
-    echo json_encode(['ok' => false, 'error' => $e->getMessage()], JSON_PRETTY_PRINT);
+    respond_error(500, 'CHART_CREATE_FAILED', 'Unable to create chart at this time.');
 }

--- a/api/chart_get.php
+++ b/api/chart_get.php
@@ -8,18 +8,30 @@ use QuantumAstrology\Charts\ChartService;
 
 header('Content-Type: application/json');
 
-$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-if ($id <= 0) {
-    http_response_code(400);
-    echo json_encode(['ok' => false, 'error' => 'id required'], JSON_PRETTY_PRINT);
+function respond_error(int $status, string $code, string $message, array $fields = []): void
+{
+    http_response_code($status);
+    echo json_encode([
+        'ok' => false,
+        'error' => [
+            'code' => $code,
+            'message' => $message,
+            'fields' => $fields,
+        ],
+    ], JSON_PRETTY_PRINT);
     exit;
+}
+
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($id <= 0) {
+    respond_error(400, 'INVALID_REQUEST', 'A positive chart id is required.', [
+        'id' => 'Provide a numeric chart id greater than zero.',
+    ]);
 }
 
 $chart = ChartService::get($id);
 if (!$chart) {
-    http_response_code(404);
-    echo json_encode(['ok' => false, 'error' => 'not found'], JSON_PRETTY_PRINT);
-    exit;
+    respond_error(404, 'NOT_FOUND', 'Chart not found.');
 }
 
 echo json_encode(['ok' => true, 'chart' => $chart], JSON_PRETTY_PRINT);

--- a/classes/Support/InputValidator.php
+++ b/classes/Support/InputValidator.php
@@ -1,0 +1,167 @@
+<?php
+# classes/Support/InputValidator.php
+declare(strict_types=1);
+
+namespace QuantumAstrology\Support;
+
+use DateTimeZone;
+use InvalidArgumentException;
+
+/**
+ * Shared helpers for normalising user-provided location and timezone inputs.
+ */
+final class InputValidator
+{
+    /**
+     * Normalise a latitude value provided in decimal degrees with optional N/S suffix.
+     *
+     * @param mixed $value Raw latitude value from user input.
+     * @param bool  $required Whether the field is required. If false, null/empty returns null.
+     */
+    public static function parseLatitude(mixed $value, bool $required = true): ?float
+    {
+        return self::parseCoordinate(
+            $value,
+            -90.0,
+            90.0,
+            'latitude',
+            ['N' => 1, 'S' => -1],
+            '34.05N',
+            $required
+        );
+    }
+
+    /**
+     * Normalise a longitude value provided in decimal degrees with optional E/W suffix.
+     *
+     * @param mixed $value Raw longitude value from user input.
+     * @param bool  $required Whether the field is required. If false, null/empty returns null.
+     */
+    public static function parseLongitude(mixed $value, bool $required = true): ?float
+    {
+        return self::parseCoordinate(
+            $value,
+            -180.0,
+            180.0,
+            'longitude',
+            ['E' => 1, 'W' => -1],
+            '118.25W',
+            $required
+        );
+    }
+
+    /**
+     * Validate and normalise a timezone identifier.
+     *
+     * @param string|null $timezone Raw timezone string.
+     * @param bool        $required Whether the field is required. If false, empty values return null.
+     */
+    public static function normaliseTimezone(?string $timezone, bool $required = true): ?string
+    {
+        $tz = trim((string) ($timezone ?? ''));
+        if ($tz === '') {
+            if ($required) {
+                throw new InvalidArgumentException(
+                    'Birth timezone is required. Please choose a location such as "America/New_York" or "Europe/London".'
+                );
+            }
+
+            return null;
+        }
+
+        try {
+            $tzObj = new DateTimeZone($tz);
+        } catch (\Exception $e) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown timezone "%s". Please use a valid IANA timezone like "America/Los_Angeles" or "Asia/Tokyo".',
+                $tz
+            ));
+        }
+
+        return $tzObj->getName();
+    }
+
+    /**
+     * @param mixed  $value
+     * @param float  $min
+     * @param float  $max
+     * @param string $label
+     * @param array<string,int> $directionMap
+     */
+    private static function parseCoordinate(
+        mixed $value,
+        float $min,
+        float $max,
+        string $label,
+        array $directionMap,
+        string $directionExample,
+        bool $required
+    ): ?float {
+        if ($value === null) {
+            if ($required) {
+                throw new InvalidArgumentException(ucfirst($label) . ' is required.');
+            }
+
+            return null;
+        }
+
+        if (is_float($value) || is_int($value)) {
+            $number = (float) $value;
+        } else {
+            $raw = trim((string) $value);
+            if ($raw === '') {
+                if ($required) {
+                    throw new InvalidArgumentException(ucfirst($label) . ' is required.');
+                }
+
+                return null;
+            }
+
+            $direction = null;
+            if (preg_match('/^([NSEW])\s*(.+)$/i', $raw, $matches)) {
+                $direction = strtoupper($matches[1]);
+                $raw = trim($matches[2]);
+            } elseif (preg_match('/^(.+?)\s*([NSEW])$/i', $raw, $matches)) {
+                $raw = trim($matches[1]);
+                $direction = strtoupper($matches[2]);
+            }
+
+            // Remove common degree symbols before validation.
+            $raw = str_replace(['°', 'º'], '', $raw);
+
+            $number = filter_var($raw, FILTER_VALIDATE_FLOAT);
+            if ($number === false) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid %s format. Use decimal degrees like "%s" or "-%.2f".',
+                    $label,
+                    $directionExample,
+                    abs($min)
+                ));
+            }
+
+            if ($direction !== null) {
+                if (!isset($directionMap[$direction])) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Invalid %s direction "%s". Use %s.',
+                        $label,
+                        $direction,
+                        implode('/', array_keys($directionMap))
+                    ));
+                }
+
+                $number = abs((float) $number) * $directionMap[$direction];
+            }
+        }
+
+        if ($number < $min || $number > $max) {
+            throw new InvalidArgumentException(sprintf(
+                'The %s must be between %.0f and %.0f degrees.',
+                $label,
+                $min,
+                $max
+            ));
+        }
+
+        return round((float) $number, 6);
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared input validator for normalising latitude/longitude and timezones
- harden the chart creation API with range checks and structured error payloads
- let the chart creation form accept N/S/E/W coordinates and surface clearer timezone errors

## Testing
- php -l classes/Support/InputValidator.php
- php -l api/chart_create.php
- php -l api/chart_get.php
- php -l pages/charts/create.php

------
https://chatgpt.com/codex/tasks/task_e_68c98ec2380c8324ba8e29e7e7de9b77