### PR TITLE
Bootstrap shared config for page routes

### DIFF
--- a/pages/_bootstrap.php
+++ b/pages/_bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+if (!defined('QUANTUM_ASTROLOGY_BOOTSTRAPPED')) {
+    define('QUANTUM_ASTROLOGY_BOOTSTRAPPED', true);
+
+    $rootPath = dirname(__DIR__);
+
+    require_once $rootPath . '/config.php';
+    require_once $rootPath . '/classes/autoload.php';
+
+    \QuantumAstrology\Core\Session::start();
+}

--- a/pages/auth/login.php
+++ b/pages/auth/login.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../_bootstrap.php';
+
 use QuantumAstrology\Core\Auth;
 use QuantumAstrology\Core\Session;
 

--- a/pages/auth/profile.php
+++ b/pages/auth/profile.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../_bootstrap.php';
+
 use QuantumAstrology\Core\Auth;
 use QuantumAstrology\Core\Session;
 

--- a/pages/auth/register.php
+++ b/pages/auth/register.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../_bootstrap.php';
+
 use QuantumAstrology\Core\Auth;
 use QuantumAstrology\Core\Session;
 use QuantumAstrology\Core\User;

--- a/pages/charts/create.php
+++ b/pages/charts/create.php
@@ -2,6 +2,8 @@
 # create.php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../_bootstrap.php';
+
 use QuantumAstrology\Core\Auth;
 use QuantumAstrology\Core\Session;
 use QuantumAstrology\Charts\Chart;

--- a/pages/charts/index.php
+++ b/pages/charts/index.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../_bootstrap.php';
+
 use QuantumAstrology\Core\Auth;
 use QuantumAstrology\Charts\Chart;
 

--- a/pages/charts/relationships.php
+++ b/pages/charts/relationships.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../_bootstrap.php';
+
 use QuantumAstrology\Core\Auth;
 use QuantumAstrology\Charts\Chart;
 

--- a/pages/charts/transits/index.php
+++ b/pages/charts/transits/index.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../../_bootstrap.php';
+
 use QuantumAstrology\Core\Auth;
 
 Auth::requireLogin();

--- a/pages/charts/view.php
+++ b/pages/charts/view.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../_bootstrap.php';
+
 use QuantumAstrology\Core\Auth;
 use QuantumAstrology\Charts\Chart;
 

--- a/pages/reports/index.php
+++ b/pages/reports/index.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../_bootstrap.php';
+
 use QuantumAstrology\Core\Auth;
 
 Auth::requireLogin();


### PR DESCRIPTION
## Summary
- add a shared `pages/_bootstrap.php` that loads configuration, registers the autoloader, and starts the session once per request
- require the shared bootstrap in the auth, chart, and report pages so they can resolve application classes before handling the request

## Testing
- php -l pages/_bootstrap.php
- php -l pages/auth/login.php
- php -l pages/auth/register.php
- php -l pages/auth/profile.php
- php -l pages/charts/index.php
- php -l pages/charts/create.php
- php -l pages/charts/relationships.php
- php -l pages/charts/transits/index.php
- php -l pages/charts/view.php
- php -l pages/reports/index.php

------
https://chatgpt.com/codex/tasks/task_e_68c9d5adb52c8324a8003e1de93c8553